### PR TITLE
Also send explicit Shift for upper case chars (OS X/qemu)

### DIFF
--- a/Flashlight-VNC/src/com/flashlight/vnc/VNCClient.as
+++ b/Flashlight-VNC/src/com/flashlight/vnc/VNCClient.as
@@ -622,7 +622,7 @@ package com.flashlight.vnc
 				var cc:uint;
                 // :?<>"{}+_)(*&^%$#@!~
                 var needsShift:Array = [];
-				var chars:String = ":?<>\"{}+_)(*&^%$#@!~";
+				var chars:String = ":?<>\"{}+_)(*&^%$#@!~ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 				var i:int = 0;
 				
 				for (i = 0; i < chars.length; i++) {


### PR DESCRIPTION
File this one under "hacks", but it appears to work around some still-unknown OS X or qemu issue (my guess is qemu).