### PR TITLE
Fix pasting to Mac OS X

### DIFF
--- a/Flashlight-VNC/src/com/flashlight/vnc/VNCClient.as
+++ b/Flashlight-VNC/src/com/flashlight/vnc/VNCClient.as
@@ -615,7 +615,7 @@ package com.flashlight.vnc
 				var cc:uint;
                 // :?<>"{}+_)(*&^%$#@!~
                 var needsShift:Array = [];
-				var chars:String = ":?<>\"{}+_)(*&^%$#@!~";
+				var chars:String = ":?<>\"{}+_)(*&^%$#@!~ABCDEFGHIJKLMNOPQRSTUVWYXZ";
 				var i:int = 0;
 				
 				for (i = 0; i < chars.length; i++) {


### PR DESCRIPTION
For some reason pasting capital letters to Mac OS X stopped working, and
instead of "fooBar" the string "foo\bar" was being sent instead. So, add
the ASCII uppercase letters to the list of characters for which shift
needs to be sent.

Tested for regressions against Windows 7 + MacOSX.