### PR TITLE
Add | to the special case list of characters for pasting

### DIFF
--- a/Flashlight-VNC/src/com/flashlight/vnc/VNCClient.as
+++ b/Flashlight-VNC/src/com/flashlight/vnc/VNCClient.as
@@ -608,7 +608,7 @@ package com.flashlight.vnc
 				var cc:uint;
                 // :?<>"{}+_)(*&^%$#@!~
                 var needsShift:Array = [];
-				var chars:String = ":?<>\"{}+_)(*&^%$#@!~ABCDEFGHIJKLMNOPQRSTUVWYXZ";
+				var chars:String = ":?<>|\"{}+_)(*&^%$#@!~ABCDEFGHIJKLMNOPQRSTUVWYXZ";
 				var i:int = 0;
 				
 				for (i = 0; i < chars.length; i++) {


### PR DESCRIPTION
If not present '|' (ASCII 0x124) appears as '\'. Tested rest of the
printable ASCII characters with the string:

     !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~

generated with the program:

    perl -e 'print join "", (grep /[[:print:]]/, map chr, 0..255), "\n"'