### PR TITLE
Communicate socket events to javascript

### DIFF
--- a/Flashlight-VNC/src/com/flashlight/vnc/VNCClient.as
+++ b/Flashlight-VNC/src/com/flashlight/vnc/VNCClient.as
@@ -133,6 +133,15 @@ package com.flashlight.vnc
 			ChangeWatcher.watch(this,"viewOnly",onViewOnlyChange);
 		}
 		
+		private static function socketEvent(evt:Event):void {
+			if (ExternalInterface.available) {
+				try {
+					ExternalInterface.call("FlashlightVncSocketEvent", evt.type);
+				} catch (e:Error) {
+				}
+			}
+		}
+
 		public function connect():void {
 			if (status !== VNCConst.STATUS_NOT_CONNECTED) disconnect();
 			
@@ -140,6 +149,10 @@ package com.flashlight.vnc
 			
 			socket = new BetterSocket();
 			
+			socket.addEventListener(Event.CONNECT, socketEvent, false, 0, true);
+			socket.addEventListener(Event.CLOSE, socketEvent, false, 0, true);
+			socket.addEventListener(IOErrorEvent.IO_ERROR, socketEvent, false, 0, true);
+			socket.addEventListener(SecurityErrorEvent.SECURITY_ERROR, socketEvent, false, 0, true);
 			socket.addEventListener(Event.CONNECT, onSocketConnect,false,0,true);
 			socket.addEventListener(ProgressEvent.SOCKET_DATA, onSocketData,false,0,true);
 			socket.addEventListener(Event.CLOSE, onSocketClose,false,0,true);


### PR DESCRIPTION
Events that occur on the connection to the VNC server are now
communicated to page via a call to the javascript function
`FlashlightVncSocketEvent`. One argument is passed to the function,
which is the event type as a string. This can be one of the following
values:
* connect
* close
* ioError
* securityError